### PR TITLE
Switch from black to ruff format

### DIFF
--- a/.github/bump_version.py
+++ b/.github/bump_version.py
@@ -19,9 +19,7 @@ def get_current_version(pyproject_path: Path) -> str:
 
 def infer_bump(changelog_dir: Path) -> str:
     fragments = [
-        f
-        for f in changelog_dir.iterdir()
-        if f.is_file() and f.name != ".gitkeep"
+        f for f in changelog_dir.iterdir() if f.is_file() and f.name != ".gitkeep"
     ]
     if not fragments:
         print("No changelog fragments found", file=sys.stderr)

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ documentation:
 	myst build docs -o docs/_build
 
 format:
-	black . -l 79
-	linecheck . --fix
+	ruff format .
 
 check-vectorization:
 	uv run python check_vectorization.py policyengine_sg/variables

--- a/changelog.d/switch-to-ruff.changed.md
+++ b/changelog.d/switch-to-ruff.changed.md
@@ -1,0 +1,1 @@
+Switch from black to ruff format.

--- a/check_vectorization.py
+++ b/check_vectorization.py
@@ -51,9 +51,7 @@ class VectorizationChecker(ast.NodeVisitor):
         if self.in_formula_method:
             # Check if this is a simple if without elif/else (might be acceptable)
             has_elif = bool(node.orelse and isinstance(node.orelse[0], ast.If))
-            has_else = bool(
-                node.orelse and not isinstance(node.orelse[0], ast.If)
-            )
+            has_else = bool(node.orelse and not isinstance(node.orelse[0], ast.If))
 
             if has_elif:
                 self.violations.append(
@@ -135,14 +133,12 @@ def main():
                 if "CRITICAL" in message:
                     critical_violations += 1
 
-    print(f"\n{'='*50}")
+    print(f"\n{'=' * 50}")
     print(f"Total violations found: {total_violations}")
     print(f"Critical violations (auto-fail): {critical_violations}")
 
     if critical_violations > 0:
-        print(
-            "\n❌ REVIEW FAILURE: Critical vectorization violations detected!"
-        )
+        print("\n❌ REVIEW FAILURE: Critical vectorization violations detected!")
         print("\nTo fix these violations:")
         print("- Replace if-elif-else with select() using default parameter")
         print("- Replace if-else with where() or boolean multiplication")

--- a/policyengine_sg/system.py
+++ b/policyengine_sg/system.py
@@ -20,6 +20,4 @@ class SingaporeTaxBenefitSystem(TaxBenefitSystem):
         self.load_parameters(os.path.join(COUNTRY_DIR, "parameters"))
 
         # Load variables
-        self.add_variables_from_directory(
-            os.path.join(COUNTRY_DIR, "variables")
-        )
+        self.add_variables_from_directory(os.path.join(COUNTRY_DIR, "variables"))

--- a/policyengine_sg/tests/test_validation_provenance.py
+++ b/policyengine_sg/tests/test_validation_provenance.py
@@ -72,9 +72,7 @@ class TestCPFContributionRates:
         """Income above $102K annual wage ceiling is not subject to CPF."""
         sim = _build({"age": 35, "employment_income": 200_000})
         # Capped at 102,000 * 20% = 20,400
-        assert _calc(sim, "cpf_employee_contribution") == pytest.approx(
-            20_400, abs=0.5
-        )
+        assert _calc(sim, "cpf_employee_contribution") == pytest.approx(20_400, abs=0.5)
 
 
 # ------------------------------------------------------------------ #
@@ -112,9 +110,7 @@ class TestPWCSample:
         assert _calc(sim, "total_income") == pytest.approx(175_000, abs=0.5)
 
     def test_cpf(self, sim):
-        assert _calc(sim, "cpf_employee_contribution") == pytest.approx(
-            20_400, abs=0.5
-        )
+        assert _calc(sim, "cpf_employee_contribution") == pytest.approx(20_400, abs=0.5)
 
     def test_reliefs(self, sim):
         assert _calc(sim, "earned_income_relief") == pytest.approx(1_000, abs=0.5)
@@ -122,9 +118,7 @@ class TestPWCSample:
         assert _calc(sim, "spouse_relief") == pytest.approx(2_000, abs=0.5)
         assert _calc(sim, "child_relief") == pytest.approx(8_000, abs=0.5)
         assert _calc(sim, "parent_relief") == pytest.approx(9_000, abs=0.5)
-        assert _calc(sim, "total_personal_reliefs") == pytest.approx(
-            40_400, abs=0.5
-        )
+        assert _calc(sim, "total_personal_reliefs") == pytest.approx(40_400, abs=0.5)
 
     def test_deductions(self, sim):
         assert _calc(sim, "donation_deduction") == pytest.approx(1_000, abs=0.5)
@@ -133,9 +127,7 @@ class TestPWCSample:
         assert _calc(sim, "chargeable_income") == pytest.approx(133_600, abs=0.5)
 
     def test_tax(self, sim):
-        assert _calc(sim, "income_tax_before_rebate") == pytest.approx(
-            9_990, abs=0.5
-        )
+        assert _calc(sim, "income_tax_before_rebate") == pytest.approx(9_990, abs=0.5)
         assert _calc(sim, "pit_rebate") == pytest.approx(200, abs=0.5)
         assert _calc(sim, "income_tax") == pytest.approx(9_790, abs=0.5)
 
@@ -175,9 +167,7 @@ class TestBuyersStampDuty:
             {"age": 35},
             {"property_purchase_price": price, "buyer_profile": "CITIZEN_FIRST"},
         )
-        assert _calc(sim, "buyers_stamp_duty") == pytest.approx(
-            expected_bsd, abs=0.5
-        )
+        assert _calc(sim, "buyers_stamp_duty") == pytest.approx(expected_bsd, abs=0.5)
 
     def test_absd_citizen_first_is_zero(self):
         """Singapore citizens buying their first property pay 0% ABSD."""

--- a/policyengine_sg/variables/gov/ecda/childcare_subsidy/childcare_subsidy.py
+++ b/policyengine_sg/variables/gov/ecda/childcare_subsidy/childcare_subsidy.py
@@ -23,7 +23,5 @@ class childcare_subsidy(Variable):
         basic_cc = where(working, p.basic_childcare, 0)
         basic_ic = where(working, p.basic_infant_care, 0)
         additional = p.additional.calc(ghi)
-        monthly = n_cc * (basic_cc + additional) + n_ic * (
-            basic_ic + additional
-        )
+        monthly = n_cc * (basic_cc + additional) + n_ic * (basic_ic + additional)
         return where(citizen, monthly * 12, 0)

--- a/policyengine_sg/variables/gov/iras/gst/gst.py
+++ b/policyengine_sg/variables/gov/iras/gst/gst.py
@@ -7,7 +7,7 @@ class gst(Variable):
     label = "Goods and Services Tax payable"
     unit = SGD
     definition_period = YEAR
-    reference = "https://www.iras.gov.sg/taxes/" "goods-services-tax-(gst)"
+    reference = "https://www.iras.gov.sg/taxes/goods-services-tax-(gst)"
 
     def formula(household, period, parameters):
         p = parameters(period).gov.iras.gst

--- a/policyengine_sg/variables/gov/iras/income_tax/cpf_top_up_relief.py
+++ b/policyengine_sg/variables/gov/iras/income_tax/cpf_top_up_relief.py
@@ -19,6 +19,4 @@ class cpf_top_up_relief(Variable):
         p = parameters(period).gov.iras.income_tax.reliefs.cpf_cash_top_up
         self_top_up = person("cpf_cash_top_up", period)
         family_top_up = person("cpf_cash_top_up_family", period)
-        return min_(self_top_up, p.self_amount) + min_(
-            family_top_up, p.family_amount
-        )
+        return min_(self_top_up, p.self_amount) + min_(family_top_up, p.family_amount)

--- a/policyengine_sg/variables/gov/iras/income_tax/donation_deduction.py
+++ b/policyengine_sg/variables/gov/iras/income_tax/donation_deduction.py
@@ -8,9 +8,7 @@ class donation_deduction(Variable):
     unit = SGD
     definition_period = YEAR
     reference = (
-        "https://www.iras.gov.sg/taxes/"
-        "other-taxes/charities/"
-        "donations-tax-deductions"
+        "https://www.iras.gov.sg/taxes/other-taxes/charities/donations-tax-deductions"
     )
 
     def formula(person, period, parameters):

--- a/policyengine_sg/variables/gov/iras/income_tax/grandparent_caregiver_relief.py
+++ b/policyengine_sg/variables/gov/iras/income_tax/grandparent_caregiver_relief.py
@@ -16,8 +16,6 @@ class grandparent_caregiver_relief(Variable):
     )
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.iras.income_tax.reliefs.grandparent_caregiver
+        p = parameters(period).gov.iras.income_tax.reliefs.grandparent_caregiver
         eligible = person("is_grandparent_caregiver", period)
         return where(eligible, p.amount, 0)

--- a/policyengine_sg/variables/gov/iras/income_tax/income_tax.py
+++ b/policyengine_sg/variables/gov/iras/income_tax/income_tax.py
@@ -7,7 +7,7 @@ class income_tax(Variable):
     label = "Income tax"
     unit = SGD
     definition_period = YEAR
-    reference = "https://www.iras.gov.sg/taxes/" "individual-income-tax"
+    reference = "https://www.iras.gov.sg/taxes/individual-income-tax"
 
     def formula(person, period, parameters):
         before_rebate = person("income_tax_before_rebate", period)

--- a/policyengine_sg/variables/gov/iras/property_tax/property_tax.py
+++ b/policyengine_sg/variables/gov/iras/property_tax/property_tax.py
@@ -8,9 +8,7 @@ class property_tax(Variable):
     unit = SGD
     definition_period = YEAR
     reference = (
-        "https://www.iras.gov.sg/taxes/"
-        "property-tax/property-owners/"
-        "property-tax-rates"
+        "https://www.iras.gov.sg/taxes/property-tax/property-owners/property-tax-rates"
     )
 
     def formula(household, period, parameters):

--- a/policyengine_sg/variables/gov/iras/stamp_duty/additional_buyers_stamp_duty.py
+++ b/policyengine_sg/variables/gov/iras/stamp_duty/additional_buyers_stamp_duty.py
@@ -7,7 +7,7 @@ from policyengine_sg.variables.input.housing.buyer_profile import (
 class additional_buyers_stamp_duty(Variable):
     value_type = float
     entity = Household
-    label = "Additional buyer's stamp duty" " on property purchase"
+    label = "Additional buyer's stamp duty on property purchase"
     unit = SGD
     definition_period = YEAR
     reference = (

--- a/policyengine_sg/variables/gov/moe/edusave/edusave_contribution.py
+++ b/policyengine_sg/variables/gov/moe/edusave/edusave_contribution.py
@@ -10,9 +10,7 @@ class edusave_contribution(Variable):
     label = "Annual Edusave account contribution"
     unit = SGD
     definition_period = YEAR
-    reference = (
-        "https://www.moe.gov.sg/" "financial-matters/edusave-account/overview"
-    )
+    reference = "https://www.moe.gov.sg/financial-matters/edusave-account/overview"
 
     def formula(person, period, parameters):
         p = parameters(period).gov.moe.edusave

--- a/policyengine_sg/variables/gov/moe/fas/moe_fas_eligible.py
+++ b/policyengine_sg/variables/gov/moe/fas/moe_fas_eligible.py
@@ -6,9 +6,7 @@ class moe_fas_eligible(Variable):
     entity = Person
     label = "Eligible for MOE Financial Assistance Scheme"
     definition_period = YEAR
-    reference = (
-        "https://www.moe.gov.sg/" "financial-matters/financial-assistance"
-    )
+    reference = "https://www.moe.gov.sg/financial-matters/financial-assistance"
 
     def formula(person, period, parameters):
         p = parameters(period).gov.moe.fas

--- a/policyengine_sg/variables/gov/mof/assurance_package/assurance_package_cash.py
+++ b/policyengine_sg/variables/gov/mof/assurance_package/assurance_package_cash.py
@@ -8,8 +8,7 @@ class assurance_package_cash(Variable):
     unit = SGD
     definition_period = YEAR
     reference = (
-        "https://www.govbenefits.gov.sg/"
-        "about-us/assurance-package/am-i-eligible/"
+        "https://www.govbenefits.gov.sg/about-us/assurance-package/am-i-eligible/"
     )
 
     def formula(person, period, parameters):

--- a/policyengine_sg/variables/gov/mof/gstv/gstv_cash.py
+++ b/policyengine_sg/variables/gov/mof/gstv/gstv_cash.py
@@ -7,7 +7,7 @@ class gstv_cash(Variable):
     label = "GST Voucher cash"
     unit = SGD
     definition_period = YEAR
-    reference = "https://www.govbenefits.gov.sg/" "about-us/gst-voucher/"
+    reference = "https://www.govbenefits.gov.sg/about-us/gst-voucher/"
 
     def formula(person, period, parameters):
         p = parameters(period).gov.mof.gstv.cash

--- a/policyengine_sg/variables/gov/mof/gstv/gstv_medisave.py
+++ b/policyengine_sg/variables/gov/mof/gstv/gstv_medisave.py
@@ -7,9 +7,7 @@ class gstv_medisave(Variable):
     label = "GST Voucher MediSave top-up"
     unit = SGD
     definition_period = YEAR
-    reference = (
-        "https://www.govbenefits.gov.sg/" "about-us/gst-voucher/am-i-eligible/"
-    )
+    reference = "https://www.govbenefits.gov.sg/about-us/gst-voucher/am-i-eligible/"
 
     def formula(person, period, parameters):
         p = parameters(period).gov.mof.gstv.medisave

--- a/policyengine_sg/variables/gov/mof/gstv/gstv_scc_rebate.py
+++ b/policyengine_sg/variables/gov/mof/gstv/gstv_scc_rebate.py
@@ -10,9 +10,7 @@ class gstv_scc_rebate(Variable):
     label = "GST Voucher S&CC rebate"
     unit = SGD
     definition_period = YEAR
-    reference = (
-        "https://www.govbenefits.gov.sg/" "about-us/gst-voucher/am-i-eligible/"
-    )
+    reference = "https://www.govbenefits.gov.sg/about-us/gst-voucher/am-i-eligible/"
 
     def formula(household, period, parameters):
         p = parameters(period).gov.mof.gstv.scc

--- a/policyengine_sg/variables/gov/mof/gstv/gstv_u_save.py
+++ b/policyengine_sg/variables/gov/mof/gstv/gstv_u_save.py
@@ -10,7 +10,7 @@ class gstv_u_save(Variable):
     label = "GST Voucher U-Save annual rebate"
     unit = SGD
     definition_period = YEAR
-    reference = "https://www.govbenefits.gov.sg/" "about-us/gst-voucher/"
+    reference = "https://www.govbenefits.gov.sg/about-us/gst-voucher/"
 
     def formula(household, period, parameters):
         p = parameters(period).gov.mof.gstv.u_save

--- a/policyengine_sg/variables/gov/mom/skills_development_levy.py
+++ b/policyengine_sg/variables/gov/mom/skills_development_levy.py
@@ -8,9 +8,7 @@ class skills_development_levy(Variable):
     unit = SGD
     definition_period = YEAR
     reference = (
-        "https://www.cpf.gov.sg/employer/"
-        "employer-obligations/"
-        "skills-development-levy"
+        "https://www.cpf.gov.sg/employer/employer-obligations/skills-development-levy"
     )
 
     def formula(person, period, parameters):

--- a/policyengine_sg/variables/gov/msf/baby_bonus/baby_bonus_cash_gift.py
+++ b/policyengine_sg/variables/gov/msf/baby_bonus/baby_bonus_cash_gift.py
@@ -8,8 +8,7 @@ class baby_bonus_cash_gift(Variable):
     unit = SGD
     definition_period = YEAR
     reference = (
-        "https://www.life.gov.sg/family-parenting/"
-        "benefits-support/baby-bonus-scheme"
+        "https://www.life.gov.sg/family-parenting/benefits-support/baby-bonus-scheme"
     )
 
     def formula(person, period, parameters):

--- a/policyengine_sg/variables/gov/msf/comcare/comcare_lta.py
+++ b/policyengine_sg/variables/gov/msf/comcare/comcare_lta.py
@@ -14,7 +14,5 @@ class comcare_lta(Variable):
         n_members = benefit_unit.nb_persons()
         capped_size = min_(n_members, p.max_household_size)
         monthly = p.amount.calc(capped_size)
-        eligible = benefit_unit.any(
-            benefit_unit.members("comcare_eligible", period)
-        )
+        eligible = benefit_unit.any(benefit_unit.members("comcare_eligible", period))
         return where(eligible, monthly * 12, 0)

--- a/policyengine_sg/variables/gov/msf/comcare/comcare_smta_eligible.py
+++ b/policyengine_sg/variables/gov/msf/comcare/comcare_smta_eligible.py
@@ -4,7 +4,7 @@ from policyengine_sg.model_api import *
 class comcare_smta_eligible(Variable):
     value_type = bool
     entity = Person
-    label = "Eligible for ComCare Short-to-Medium-Term" " Assistance"
+    label = "Eligible for ComCare Short-to-Medium-Term Assistance"
     definition_period = YEAR
     reference = (
         "https://www.msf.gov.sg/what-we-do/comcare",

--- a/policyengine_sg/variables/input/demographics/is_nsman.py
+++ b/policyengine_sg/variables/input/demographics/is_nsman.py
@@ -4,6 +4,6 @@ from policyengine_sg.model_api import *
 class is_nsman(Variable):
     value_type = bool
     entity = Person
-    label = "Whether the person performed" " national service activities"
+    label = "Whether the person performed national service activities"
     definition_period = YEAR
     default_value = False

--- a/policyengine_sg/variables/input/demographics/is_pr.py
+++ b/policyengine_sg/variables/input/demographics/is_pr.py
@@ -4,6 +4,6 @@ from policyengine_sg.model_api import *
 class is_pr(Variable):
     value_type = bool
     entity = Person
-    label = "Whether the person is a Singapore" " permanent resident"
+    label = "Whether the person is a Singapore permanent resident"
     definition_period = YEAR
     default_value = False

--- a/policyengine_sg/variables/input/family/is_grandparent_caregiver.py
+++ b/policyengine_sg/variables/input/family/is_grandparent_caregiver.py
@@ -5,8 +5,7 @@ class is_grandparent_caregiver(Variable):
     value_type = bool
     entity = Person
     label = (
-        "Whether a working mother uses grandparent"
-        " caregiver for child aged 12 or below"
+        "Whether a working mother uses grandparent caregiver for child aged 12 or below"
     )
     definition_period = YEAR
     default_value = False

--- a/policyengine_sg/variables/input/family/number_of_children_born_before_2024.py
+++ b/policyengine_sg/variables/input/family/number_of_children_born_before_2024.py
@@ -4,9 +4,6 @@ from policyengine_sg.model_api import *
 class number_of_children_born_before_2024(Variable):
     value_type = int
     entity = Person
-    label = (
-        "Number of qualifying children born or"
-        " adopted before 1 January 2024"
-    )
+    label = "Number of qualifying children born or adopted before 1 January 2024"
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/family/number_of_children_in_childcare.py
+++ b/policyengine_sg/variables/input/family/number_of_children_in_childcare.py
@@ -5,8 +5,7 @@ class number_of_children_in_childcare(Variable):
     value_type = int
     entity = Person
     label = (
-        "Number of children enrolled in licensed"
-        " childcare (age 18 months to 6 years)"
+        "Number of children enrolled in licensed childcare (age 18 months to 6 years)"
     )
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/family/number_of_children_in_infant_care.py
+++ b/policyengine_sg/variables/input/family/number_of_children_in_infant_care.py
@@ -4,9 +4,6 @@ from policyengine_sg.model_api import *
 class number_of_children_in_infant_care(Variable):
     value_type = int
     entity = Person
-    label = (
-        "Number of children enrolled in licensed"
-        " infant care (age 2 to 18 months)"
-    )
+    label = "Number of children enrolled in licensed infant care (age 2 to 18 months)"
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/family/number_of_children_in_kindergarten.py
+++ b/policyengine_sg/variables/input/family/number_of_children_in_kindergarten.py
@@ -4,9 +4,6 @@ from policyengine_sg.model_api import *
 class number_of_children_in_kindergarten(Variable):
     value_type = int
     entity = Person
-    label = (
-        "Number of children enrolled in an"
-        " Anchor Operator or MOE kindergarten"
-    )
+    label = "Number of children enrolled in an Anchor Operator or MOE kindergarten"
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/family/number_of_children_in_student_care.py
+++ b/policyengine_sg/variables/input/family/number_of_children_in_student_care.py
@@ -4,6 +4,6 @@ from policyengine_sg.model_api import *
 class number_of_children_in_student_care(Variable):
     value_type = int
     entity = Person
-    label = "Number of children in MSF-registered" " student care centres"
+    label = "Number of children in MSF-registered student care centres"
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/family/number_of_dependant_parents_not_living.py
+++ b/policyengine_sg/variables/input/family/number_of_dependant_parents_not_living.py
@@ -4,6 +4,6 @@ from policyengine_sg.model_api import *
 class number_of_dependant_parents_not_living(Variable):
     value_type = int
     entity = Person
-    label = "Number of dependant parents" " not living with taxpayer"
+    label = "Number of dependant parents not living with taxpayer"
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/family/number_of_disabled_parents.py
+++ b/policyengine_sg/variables/input/family/number_of_disabled_parents.py
@@ -4,8 +4,6 @@ from policyengine_sg.model_api import *
 class number_of_disabled_parents(Variable):
     value_type = int
     entity = Person
-    label = (
-        "Number of dependant parents" " with disability living with taxpayer"
-    )
+    label = "Number of dependant parents with disability living with taxpayer"
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/family/number_of_disabled_parents_not_living.py
+++ b/policyengine_sg/variables/input/family/number_of_disabled_parents_not_living.py
@@ -4,9 +4,6 @@ from policyengine_sg.model_api import *
 class number_of_disabled_parents_not_living(Variable):
     value_type = int
     entity = Person
-    label = (
-        "Number of dependant parents with"
-        " disability not living with taxpayer"
-    )
+    label = "Number of dependant parents with disability not living with taxpayer"
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/housing/is_first_time_homebuyer.py
+++ b/policyengine_sg/variables/input/housing/is_first_time_homebuyer.py
@@ -4,8 +4,6 @@ from policyengine_sg.model_api import *
 class is_first_time_homebuyer(Variable):
     value_type = bool
     entity = Person
-    label = (
-        "Is a first-time homebuyer (never owned HDB or received housing grant)"
-    )
+    label = "Is a first-time homebuyer (never owned HDB or received housing grant)"
     definition_period = YEAR
     default_value = False

--- a/policyengine_sg/variables/input/housing/property_annual_value.py
+++ b/policyengine_sg/variables/input/housing/property_annual_value.py
@@ -9,7 +9,5 @@ class property_annual_value(Variable):
     definition_period = YEAR
     default_value = 0
     reference = (
-        "https://www.iras.gov.sg/taxes/"
-        "property-tax/property-owners/"
-        "property-tax-rates"
+        "https://www.iras.gov.sg/taxes/property-tax/property-owners/property-tax-rates"
     )

--- a/policyengine_sg/variables/input/income/cpf_cash_top_up_family.py
+++ b/policyengine_sg/variables/input/income/cpf_cash_top_up_family.py
@@ -4,7 +4,7 @@ from policyengine_sg.model_api import *
 class cpf_cash_top_up_family(Variable):
     value_type = float
     entity = Person
-    label = "CPF cash top-up amount for family members'" " retirement accounts"
+    label = "CPF cash top-up amount for family members' retirement accounts"
     unit = SGD
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/income/donation_amount.py
+++ b/policyengine_sg/variables/input/income/donation_amount.py
@@ -9,6 +9,5 @@ class donation_amount(Variable):
     definition_period = YEAR
     default_value = 0
     reference = (
-        "https://www.iras.gov.sg/taxes/"
-        "other-taxes/charities/donations-tax-deductions"
+        "https://www.iras.gov.sg/taxes/other-taxes/charities/donations-tax-deductions"
     )

--- a/policyengine_sg/variables/input/income/household_income_per_capita.py
+++ b/policyengine_sg/variables/input/income/household_income_per_capita.py
@@ -4,7 +4,7 @@ from policyengine_sg.model_api import *
 class household_income_per_capita(Variable):
     value_type = float
     entity = Person
-    label = "Monthly household income per capita" " for benefit eligibility"
+    label = "Monthly household income per capita for benefit eligibility"
     unit = SGD
     definition_period = YEAR
     default_value = 0

--- a/policyengine_sg/variables/input/income/ptr_balance.py
+++ b/policyengine_sg/variables/input/income/ptr_balance.py
@@ -4,10 +4,7 @@ from policyengine_sg.model_api import *
 class ptr_balance(Variable):
     value_type = float
     entity = Person
-    label = (
-        "Remaining parenthood tax rebate balance"
-        " carried forward from prior years"
-    )
+    label = "Remaining parenthood tax rebate balance carried forward from prior years"
     unit = SGD
     definition_period = YEAR
     default_value = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,7 @@ dependencies = [
 dev = [
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
-    "black>=24.8.0",
-    "linecheck>=0.1.0",
+    "ruff>=0.9.0",
     "jupyter-book>=1.0.4",
     "mystmd>=1.3.17",
     "wheel>=0.38.4",
@@ -63,10 +62,6 @@ Homepage = "https://policyengine.org"
 Repository = "https://github.com/PolicyEngine/policyengine-sg"
 Documentation = "https://policyengine.org/sg/api"
 Tracker = "https://github.com/PolicyEngine/policyengine-sg/issues"
-
-[tool.black]
-line-length = 79
-target-version = ["py310", "py311", "py312", "py313"]
 
 [tool.pytest.ini_options]
 testpaths = ["policyengine_sg/tests"]


### PR DESCRIPTION
## Summary
- Replace black and linecheck with ruff>=0.9.0 in dev dependencies
- Update Makefile to use `ruff format .` instead of `black . -l 79` and `linecheck . --fix`
- Remove `[tool.black]` section from pyproject.toml
- Reformat all files with ruff defaults (88 char line length)

## Test plan
- [x] `ruff format --check .` passes
- [ ] CI checks pass

Generated with [Claude Code](https://claude.com/claude-code)