### PR TITLE
Use org-level reusable workflows for lint and changelog

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,17 +5,7 @@ on:
     branches: [main, master]
 
 jobs:
+  Lint:
+    uses: PolicyEngine/.github/.github/workflows/lint.yml@main
   check-changelog:
-    name: Check changelog fragment
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check for changelog fragment
-        run: |
-          FRAGMENTS=$(find changelog.d -type f ! -name '.gitkeep' | wc -l)
-          if [ "$FRAGMENTS" -eq 0 ]; then
-            echo "::error::No changelog fragment found in changelog.d/"
-            echo "Add one with: echo 'Description.' > changelog.d/\$(git branch --show-current).<type>.md"
-            echo "Types: added, changed, fixed, removed, breaking"
-            exit 1
-          fi
+    uses: PolicyEngine/.github/.github/workflows/changelog.yml@main

--- a/changelog.d/use-reusable-workflows.changed.md
+++ b/changelog.d/use-reusable-workflows.changed.md
@@ -1,0 +1,1 @@
+Use org-level reusable GitHub Actions workflows for lint and changelog checks.


### PR DESCRIPTION
## Summary

- Replaces inline changelog check with the reusable workflow from `PolicyEngine/.github`
- Adds a Lint job (previously missing from this repo's PR CI)
- Simplifies pr.yaml from 21 lines to 11 lines

## Dependencies

- Requires PolicyEngine/.github#1 to be merged first

## Test plan

- [ ] Merge PolicyEngine/.github#1 first
- [ ] Verify Lint job passes using the reusable workflow
- [ ] Verify changelog check passes using the reusable workflow

Generated with [Claude Code](https://claude.com/claude-code)